### PR TITLE
feat: upgrade runtime to python3.11 and update dependencies for security fixes

### DIFF
--- a/requirements_layer/requirements.txt
+++ b/requirements_layer/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.26.74
-requests==2.28.2
-jq==1.4.0
-pyyaml==6.0
+boto3==1.35.28
+requests==2.32.3
+jq==1.8.0
+pyyaml==6.0.2

--- a/template.yaml
+++ b/template.yaml
@@ -60,7 +60,7 @@ Globals:
     Timeout: 900
     MemorySize: 2048
     Handler: app.lambda_handler
-    Runtime: python3.9
+    Runtime: python3.11
     Layers:
       - !Ref RequirementsLayer
     Architectures:
@@ -111,9 +111,9 @@ Resources:
       CompatibleArchitectures:
         - arm64
       CompatibleRuntimes:
-        - python3.9
+        - python3.11
     Metadata:
-      BuildMethod: python3.9
+      BuildMethod: python3.11
       BuildArchitecture: arm64
 
   LambdaFunction:


### PR DESCRIPTION
## Summary
Upgraded Lambda runtime from Python 3.9 to Python 3.11 and updated all dependencies to their latest secure versions to address CVE vulnerabilities in the requirements layer.

## Changes
- Upgraded runtime from python3.9 to python3.11 in template.yaml
- Updated requirements layer configuration to support python3.11
- Updated dependencies to latest secure versions:
  - boto3: 1.26.74 → 1.35.28
  - requests: 2.28.2 → 2.32.3
  - jq: 1.4.0 → 1.8.0
  - pyyaml: 6.0 → 6.0.2
- Successfully deployed and tested with RequirementsLayer:4